### PR TITLE
ci: add Dependabot config, PR checks, and auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Python backend dependencies (api/requirements.txt)
+  - package-ecosystem: "pip"
+    directory: "/api"
+    schedule:
+      interval: "daily"
+    groups:
+      pip-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Container base image (Dockerfile)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      docker-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions used by the workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,28 @@
+name: checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  # Builds the multi-stage image. This is the highest-value gate: it exercises the
+  # Dockerfile base-image bump and proves api/requirements.txt installs cleanly inside
+  # the image (the builder stage runs `pip install -r requirements.txt`).
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build -t wally:ci .
+
+  # Installs the backend deps and imports the app package, so a dependency bump that
+  # breaks an import is caught (a plain syntax check would miss runtime import errors).
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - run: pip install -r api/requirements.txt
+      - run: python -c "import api.main; print('import OK')"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,24 @@
+name: dependabot-automerge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    # Majors are left for human review; minor/patch merge once the
+    # required checks pass. Requires repo auto-merge enabled and a
+    # ruleset marking the checks as required — without required checks,
+    # --auto merges immediately.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: meta
+      - if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,5 @@
-bcrypt
-fastapi[standard]
-PyJWT
-python-dateutil
-sqlmodel
+bcrypt==5.0.0
+fastapi[standard]==0.136.3
+PyJWT==2.13.0
+python-dateutil==2.9.0.post0
+sqlmodel==0.0.38


### PR DESCRIPTION
## What

Sets up Dependabot with automatic merging of **minor/patch** PRs, gated on real CI — mirroring the setup in the `FileSync` and `fsend` repos.

Three new files:

### `.github/dependabot.yml`
Daily checks for three ecosystems, grouped by minor/patch:
- **pip** (`/api`) — backend dependencies
- **docker** (`/`) — Dockerfile base image
- **github-actions** (`/`) — actions used by the workflows

### `.github/workflows/checks.yml` (runs on every PR + push to main)
Wally had no CI running on PRs, so there was nothing for auto-merge to wait on. This adds:
- **`docker`** — builds the multi-stage image. Validates the Dockerfile base-image bump *and* that `api/requirements.txt` installs cleanly (the builder stage runs `pip install`).
- **`python`** — installs the backend deps and imports `api.main`, catching a dependency bump that breaks an import.

### `.github/workflows/dependabot-automerge.yml`
- Only acts on PRs authored by `dependabot[bot]` (the `if:` gate).
- Enables `--auto --squash` for **minor/patch** updates; **majors are excluded** for manual review.
- Auto-merge waits for the required checks before merging.

## Repo settings (applied separately, not in this PR)
- **Allow auto-merge** enabled.
- **Branch protection on `main`** requiring the `docker` and `python` checks (no approval required; admins can bypass).
- **Auto-delete merged branches** enabled.

Once merged, Dependabot minor/patch PRs will merge themselves once `docker` + `python` are green. Majors and other contributors' PRs still require a manual merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)